### PR TITLE
Update README.md and fixes Issue #1

### DIFF
--- a/pocketbase/README.md
+++ b/pocketbase/README.md
@@ -8,8 +8,8 @@ Change to the pocketbase directory in the terminal and execute the following com
 └─ Admin UI: http://127.0.0.1:8090/_/
 
   You can log in as follows
-**Username:** admin@admin.com 
-**Password:** Admin1234!
+**Username:** admin@demo.com 
+**Password:** admin12345!
 
 -------------------------------------------------------
 ## As Docker


### PR DESCRIPTION
Fixed issue #1 


![fix](https://github.com/user-attachments/assets/bad5aaa3-7d7c-42d2-a522-1cc62d53937e)

The admin email and password were both incorrect in the readme. After querying the database for the actual email and using the same password cadence as the other readme, `admin12345!` was the correct password. 

Without knowing how to log into the admin half of this project would not be usable. 